### PR TITLE
added Netflix data Gibbs sampling in notebook; doc cleaning

### DIFF
--- a/code/bpmf_gibbs_sampler.R
+++ b/code/bpmf_gibbs_sampler.R
@@ -4,6 +4,10 @@ source("code/bpmf_utils.R")
 
 initialize_UV <- function(k_estimate, n_users, n_movies) {
   # Initializes U and V latent feature matrices
+  #' @param k_estimate: number of latent features
+  #' @param n_users: number of users
+  #' @param n_movies: number of movies
+  #' @return List[U_init, V_init]
   U_init <- 1:n_users %>% Map(function(x) {
     sampled_covariance <- rWishart(1, k_estimate, diag(k_estimate))[,,1]
     rmvnorm(1, mean=rep(0, k_estimate), sigma=sampled_covariance)

--- a/code/bpmf_utils.R
+++ b/code/bpmf_utils.R
@@ -1,6 +1,5 @@
 # Functions for BPMF Gibbs Sampler
 
-# Define helper functions to re-use for U and V
 compute_U_bar <- function(latent_matrix, N) {
   U_bar <- colSums(latent_matrix) / N
   return(U_bar)
@@ -11,87 +10,89 @@ compute_S_bar <- function(latent_matrix, N) {
   return(S_bar)
 }
 
-compute_mu_0_star <- function(beta_0_prev, mu_0_prev, latent_matrix, N) {
-  return((beta_0_prev * mu_0_prev + N * compute_U_bar(latent_matrix, N)) / (beta_0_prev + N))
+compute_mu_0_star <- function(beta_0, mu_0, latent_matrix, N) {
+  return((beta_0 * mu_0 + N * compute_U_bar(latent_matrix, N)) / (beta_0 + N))
 }
 
-compute_beta_0_star <- function(beta_0_prev, N) {
-  return(beta_0_prev + N)
+compute_beta_0_star <- function(beta_0, N) {
+  return(beta_0 + N)
 }
 
 compute_nu_0_star <- function(nu_0_prev, N) {
   return(nu_0_prev + N)
 } 
 
-compute_W_0_star <- function(W_0, latent_matrix, N, mu_0_prev, beta_0_prev) {
+compute_W_0_star <- function(W_0, latent_matrix, N, mu_0, beta_0) {
   W_0_inv <- solve(W_0)
   S_bar <- compute_S_bar(latent_matrix, N)
   U_bar <- compute_U_bar(latent_matrix, N)
-  W_0_star_inv <- (W_0_inv + N * S_bar + ((beta_0 * N) / (beta_0 + N)) * ((mu_0_prev - U_bar) %*% t(mu_0_prev - U_bar)))
+  W_0_star_inv <- (W_0_inv + N * S_bar + ((beta_0 * N) / (beta_0 + N)) * ((mu_0 - U_bar) %*% t(mu_0 - U_bar)))
   W_0_star <- solve(W_0_star_inv)
   return(W_0_star)
 }
 
-# Define theta_U sampler
-sample_theta_U <- function(U_prev, mu_0_prev, beta_0_prev, nu_0_prev, W_0_prev, n_users) {
-  # @param U_prev: Matrix[n_users: Integer, k: Integer]
-  # @param mu_0_prev: Matrix[n_users: Integer, 1]
-  # @param beta_0_prev: Scalar: Integer
-  # @param nu_0_prev: Scalar: Integer
-  # @param W_0_prev: Matrix[k: Integer, k: Integer]
-  # @param n_users: Scalar: Integer
-  # @return tuple(mu_U, Lambda_U)
+sample_theta_U <- function(U, mu_0, beta_0, nu_0, W_0, n_users) {
+  # Samples hyperparameters for U
+  #' @param U: Matrix[n_users: Integer, k: Integer]
+  #' @param mu_0: Matrix[n_users: Integer, 1]
+  #' @param beta_0: Scalar: Integer
+  #' @param nu_0: Scalar: Integer
+  #' @param W_0: Matrix[k: Integer, k: Integer]
+  #' @param n_users: Scalar: Integer
+  #' @return List[mu_U, Lambda_U]
   
-  nu_0_star_U <- compute_nu_0_star(nu_0_prev, n_users)
-  W_star_U <- compute_W_0_star(W_0_prev, U_prev, n_users, mu_0_prev, beta_0_prev)
-  mu_star_U <- compute_mu_0_star(beta_0_prev, mu_0_prev, U_prev, n_users)
+  nu_0_star_U <- compute_nu_0_star(nu_0, n_users)
+  W_star_U <- compute_W_0_star(W_0, U, n_users, mu_0, beta_0)
+  mu_star_U <- compute_mu_0_star(beta_0, mu_0, U, n_users)
   
   Lambda_U <- rWishart(1, nu_0_star_U, W_star_U)[,,1]
   mu_U <- rmvnorm(1, mu_star_U, Lambda_U)
   return(list(mu_U, Lambda_U))
 }
 
-# Define theta_V sampler
-sample_theta_V <- function(V_prev, mu_0_prev, beta_0_prev, nu_0_prev, W_0_prev, n_movies) {
-  # @param V_prev: Matrix[n_movies: Integer, k: Integer]
-  # @param mu_0_prev: Matrix[n_users: Integer, 1]
-  # @param beta_0_prev: Scalar: Integer
-  # @param nu_0_prev: Scalar: Integer
-  # @param W_0_prev: Matrix[k: Integer, k: Integer]
-  # @param n_movies: Scalar: Integer
-  # @return tuple(mu_V, Lambda_V)
+
+sample_theta_V <- function(V, mu_0, beta_0, nu_0, W_0, n_movies) {
+  # Samples hyperparameters for V
+  #' @param V: Matrix[n_movies: Integer, k: Integer]
+  #' @param mu_0: Matrix[n_users: Integer, 1]
+  #' @param beta_0: Scalar: Integer
+  #' @param nu_0: Scalar: Integer
+  #' @param W_0: Matrix[k: Integer, k: Integer]
+  #' @param n_movies: Scalar: Integer
+  #' @return tuple(mu_V, Lambda_V)
   
-  nu_0_star_V <- compute_nu_0_star(nu_0_prev, n_movies)
-  W_star_V <- compute_W_0_star(W_0_prev, V_prev, n_movies, mu_0_prev, beta_0_prev)
-  mu_star_V <- compute_mu_0_star(beta_0_prev, mu_0_prev, V_prev, n_movies)
+  nu_0_star_V <- compute_nu_0_star(nu_0, n_movies)
+  W_star_V <- compute_W_0_star(W_0, V, n_movies, mu_0, beta_0)
+  mu_star_V <- compute_mu_0_star(beta_0, mu_0, V, n_movies)
   
   Lambda_V <- rWishart(1, nu_0_star_V, W_star_V)[,,1]
   mu_V <- rmvnorm(1, mu_star_V, Lambda_V)
   return(list(mu_V, Lambda_V))
 }
 
-# Define helper function to retrieve movie observation mask
 extract_user_observation_index <- function(R, user_index) {
-  # @param R: Sparse Matrix
-  # @param user_index: Integer
-  # @return tuple(observations)
+  # Define helper function to retrieve movie observation mask
+  #' @param R: Sparse Matrix
+  #' @param user_index: Integer
+  #' @return Array of observations
   return(R[R[,1] == user_index, 2])
 }
 
 extract_user_observation_ratings <- function(R, user_index) {
-  # @param R: Sparse Matrix
-  # @param user_index: Integer
-  # @return tuple(observations)
+  # Define helper function to retrieve movie ratings for given user_index
+  #' @param R: Sparse Matrix
+  #' @param user_index: Integer
+  #' @return tuple(observations)
   return(R[R[,1] == user_index, 3])
 }
 
 
-# Define function to sample from U_i
 sample_U_i <- function(R, mu_U, Lambda_U, V, alpha, user_index, k) {
-  # @param R: Sparse Matrix[user_index, movie_index, rating]
-  # @param mu_U: Scalar
-  # @param Lambda_U: Matrix[k, k]
-  # @return U_i: Matrix[1, k]
+  # Define function to sample from U_i
+  #' @param R: Sparse Matrix[user_index, movie_index, rating]
+  #' @param mu_U: Scalar
+  #' @param Lambda_U: Matrix[k, k]
+  #' @return U_i: Matrix[1, k]
   user_observation_mask <- extract_user_observation_index(R, user_index)
   user_ratings <- extract_user_observation_ratings(R, user_index)
   num_unobserved <- nrow(V) - length(user_observation_mask)
@@ -104,15 +105,16 @@ sample_U_i <- function(R, mu_U, Lambda_U, V, alpha, user_index, k) {
   return(U_i_sampled)
 }
 
-# Define function to construct U from sampled U_i
 sample_U <- function(R, mu_U, Lambda_U, V, alpha, k, n_users) {
-  # @param R: Sparse Matrix[user_index, movie_index, rating]
-  # @param mu_U: Scalar
-  # @param Lambda_U: Matrix[k x k]
-  # @param V: Matrix[n_users, k]
-  # @param alpha: Scalar
-  # @param k: Scalar
-  # @param n_users: Scalar
+  # Define function to construct U from sampled U_i
+  #' @param R: Sparse Matrix[user_index, movie_index, rating]
+  #' @param mu_U: Scalar
+  #' @param Lambda_U: Matrix[k x k]
+  #' @param V: Matrix[n_users, k]
+  #' @param alpha: Scalar
+  #' @param k: Scalar
+  #' @param n_users: Scalar
+  #' @return sampled_U: Matrix[n_users, k]
   sampled_U <- c()
   for (i in 1:n_users) {
     u_i <- sample_U_i(R, mu_U, Lambda_U, V, alpha, i, k)
@@ -121,28 +123,28 @@ sample_U <- function(R, mu_U, Lambda_U, V, alpha, k, n_users) {
   return(sampled_U)
 }
 
-# Define helper function to retrieve user observation mask
 extract_movie_observation_index <- function(R, movie_index) {
-  # @param R: Sparse Matrix
-  # @param movie_index: Integer
-  # @return tuple(observations)
+  # Define helper function to retrieve user observation mask
+  #' @param R: Sparse Matrix
+  #' @param movie_index: Integer
+  #' @return tuple(observations)
   return(R[R[,2] == movie_index, 1])
 }
 
 extract_movie_observation_ratings <- function(R, movie_index) {
-  # @param R: Sparse Matrix
-  # @param user_index: Integer
-  # @return tuple(observations)
+  # Define helper function to retrieve user ratings for a given movie
+  #' @param R: Sparse Matrix
+  #' @param user_index: Integer
+  #' @return tuple(observations)
   return(R[R[,2] == movie_index, 3])
 }
 
-
-# Define function to sample from U_i
 sample_V_i <- function(R, mu_V, Lambda_V, U, alpha, movie_index, k) {
-  # @param R: Sparse Matrix[user_index, movie_index, rating]
-  # @param mu_V: Scalar
-  # @param Lambda_V: Matrix[k, k]
-  # @return V_i: Matrix[1, k]
+  # Define function to sample from V_i
+  #' @param R: Sparse Matrix[user_index, movie_index, rating]
+  #' @param mu_V: Scalar
+  #' @param Lambda_V: Matrix[k, k]
+  #' @return V_i: Matrix[1, k]
   movie_observation_mask <- extract_movie_observation_index(R, movie_index)
   movie_ratings <- extract_movie_observation_ratings(R, movie_index)
   num_unobserved <- nrow(U) - length(movie_observation_mask)
@@ -155,15 +157,16 @@ sample_V_i <- function(R, mu_V, Lambda_V, U, alpha, movie_index, k) {
   return(V_i_sampled)
 }
 
-# Define function to construct U from sampled U_i
 sample_V <- function(R, mu_V, Lambda_V, U, alpha, k, n_movies) {
-  # @param R: Sparse Matrix[user_index, movie_index, rating]
-  # @param mu_V: Scalar
-  # @param Lambda_V: Matrix[k x k]
-  # @param U: Matrix[n_movies, k]
-  # @param alpha: Scalar
-  # @param k: Scalar
-  # @param n_movies: Scalar
+  # Define function to construct U from sampled U_i
+  #' @param R: Sparse Matrix[user_index, movie_index, rating]
+  #' @param mu_V: Scalar
+  #' @param Lambda_V: Matrix[k x k]
+  #' @param U: Matrix[n_movies, k]
+  #' @param alpha: Scalar
+  #' @param k: Scalar
+  #' @param n_movies: Scalar
+  #' @return V: Matrix[n_movies, k]
   sampled_V <- c()
   for (i in 1:n_movies) {
     v_i <- sample_V_i(R, mu_V, Lambda_V, U, alpha, i, k)

--- a/stat_280_project_netflix_recsys.Rmd
+++ b/stat_280_project_netflix_recsys.Rmd
@@ -75,7 +75,7 @@ movies %>% head
 ratings %>%
   group_by(movieId) %>%
   summarise(mean_rating=mean(rating), count=n()) %>%
-  filter(n >= 1000) %>% 
+  filter(count >= 1000) %>% 
   arrange(desc(mean_rating)) %>% 
   head(100) %>% 
   left_join(movies, by=c("movieId")) %>% 

--- a/stat_280_project_netflix_recsys.Rmd
+++ b/stat_280_project_netflix_recsys.Rmd
@@ -60,12 +60,7 @@ ratings %>% summarise(nrows=n(),
                       max_rating=max(rating))
 ```
 
-```{r}
-# Sample ratings
-sampled_ratings <- sample_ratings(ratings, 100, 100)
-sampled_ratings %>% summarise(n_users=n_distinct(userId),
-                              n_movies=n_distinct(movieId))
-```
+
 
 
 ```{r}
@@ -79,8 +74,8 @@ movies %>% head
 # Top 100 Movies by mean ratings with at least 1000 
 ratings %>%
   group_by(movieId) %>%
-  summarise(mean_rating=mean(rating), count=n()) %>% 
-  filter(count > 1000) %>% 
+  summarise(mean_rating=mean(rating), count=n()) %>%
+  filter(n >= 1000) %>% 
   arrange(desc(mean_rating)) %>% 
   head(100) %>% 
   left_join(movies, by=c("movieId")) %>% 
@@ -352,5 +347,91 @@ simulations.dt %>%
 ```
 
 
+## Netflix Data
 
+In this section, we apply the BPMF Gibbs Sampler to our sampled ratings data set on 15 users and 25 movies.
+
+```{r}
+# Sample ratings
+sampled_ratings <- sample_ratings(ratings, 25, 25)
+sampled_ratings %>% summarise(n_users=n_distinct(userId),
+                              n_movies=n_distinct(movieId),
+                              n_ratings=n())
+```
+
+
+```{r}
+# Apply mapping from userId -> userKey and movieId -> movieKey
+# This allows it to work with the Gibbs Sampler which assumes 1:n_users as
+# indices for users and 1:n_movies as indices for movies
+sampled_ratings_user_key <- sampled_ratings %>%
+  select(userId) %>%
+  distinct %>%
+  mutate(user_key=row_number())
+
+sampled_ratings_movie_key <- sampled_ratings %>%
+  select(movieId) %>%
+  distinct %>%
+  mutate(movie_key=row_number())
+
+sampled_ratings_mapped <- sampled_ratings %>%
+  left_join(sampled_ratings_user_key, by="userId") %>% 
+  left_join(sampled_ratings_movie_key, by="movieId") %>% 
+  select(user_key, movie_key, rating)
+
+sampled_ratings_mapped %>% head
+```
+
+```{r}
+sampled_ratings_mapped %>%
+  vis_matrix(data = .,
+             row_col = "user_key",
+             column_col = "movie_key",
+             value_col = "rating")
+```
+
+```{r}
+# Implement Gibbs sampler
+n_replications <- 800
+
+# Define initial parameters
+k_estimate <- 10
+alpha <- 1
+mu_0 <- rep(0, k_estimate)
+beta_0 <- 1
+nu_0 <- 1
+W_0 <- diag(k_estimate)
+
+sampled_ratings_matrix <- sampled_ratings_mapped %>%
+  mutate(rating=(rating - 1)/5) %>% 
+  select(user_key, movie_key, rating) %>%
+  as.matrix
+
+n_users <- sampled_ratings_mapped %>%
+  summarise(n_users=n_distinct(user_key)) %>%
+  as.numeric()
+
+n_movies <- sampled_ratings_mapped %>%
+  summarise(n_movies=n_distinct(movie_key)) %>%
+  as.numeric()
+
+# Run
+netflix_bpmf_gibbs_results <- BPMF_Gibbs_Sampler(
+  sampled_ratings_matrix, 
+  k_estimate, 
+  n_replications, 
+  n_users, 
+  n_movies, 
+  mu_0, beta_0, nu_0, W_0, alpha
+)
+```
+
+```{r}
+sampled_ratings_matrix
+```
+
+
+```{r}
+netflix_bpmf_gibbs_results$Rs[[800]]
+```
 

--- a/stat_280_project_netflix_recsys.Rmd
+++ b/stat_280_project_netflix_recsys.Rmd
@@ -352,8 +352,9 @@ simulations.dt %>%
 In this section, we apply the BPMF Gibbs Sampler to our sampled ratings data set on 15 users and 25 movies.
 
 ```{r}
+set.seed(1)
 # Sample ratings
-sampled_ratings <- sample_ratings(ratings, 25, 25)
+sampled_ratings <- sample_ratings(ratings, 30, 30)
 sampled_ratings %>% summarise(n_users=n_distinct(userId),
                               n_movies=n_distinct(movieId),
                               n_ratings=n())
@@ -392,10 +393,10 @@ sampled_ratings_mapped %>%
 
 ```{r}
 # Implement Gibbs sampler
-n_replications <- 800
+n_replications <- 1000
 
 # Define initial parameters
-k_estimate <- 10
+k_estimate <- 15
 alpha <- 1
 mu_0 <- rep(0, k_estimate)
 beta_0 <- 1
@@ -403,7 +404,7 @@ nu_0 <- 1
 W_0 <- diag(k_estimate)
 
 sampled_ratings_matrix <- sampled_ratings_mapped %>%
-  mutate(rating=(rating - 1)/5) %>% 
+  mutate(rating=sapply(rating, transform_rating_to_score)) %>% 
   select(user_key, movie_key, rating) %>%
   as.matrix
 
@@ -414,7 +415,9 @@ n_users <- sampled_ratings_mapped %>%
 n_movies <- sampled_ratings_mapped %>%
   summarise(n_movies=n_distinct(movie_key)) %>%
   as.numeric()
+```
 
+```{r}
 # Run
 netflix_bpmf_gibbs_results <- BPMF_Gibbs_Sampler(
   sampled_ratings_matrix, 
@@ -426,12 +429,16 @@ netflix_bpmf_gibbs_results <- BPMF_Gibbs_Sampler(
 )
 ```
 
+
 ```{r}
-sampled_ratings_matrix
+# Visualize posterior untransformed
+viz_posterior_rating(21, 30, sampled_ratings_mapped, netflix_bpmf_gibbs_results, transformed = FALSE)
+```
+
+```{r}
+# Visualize posterior transformed
+viz_posterior_rating(21, 30, sampled_ratings_mapped, netflix_bpmf_gibbs_results, transformed = TRUE)
 ```
 
 
-```{r}
-netflix_bpmf_gibbs_results$Rs[[800]]
-```
 


### PR DESCRIPTION
Applied BPMF Gibbs to sampled Netflix data in notebook; works by mapping sampled users and movies to keys from `1:n_users` and `1:n_movies`, respectively. Can use to reverse map to original `userId` and `movieId`:

![image](https://user-images.githubusercontent.com/57904108/69489007-78616000-0ead-11ea-8e73-a5cd7e748ac2.png)
